### PR TITLE
fix: change myWorspace api dto & s3Service image URL substring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 
 	// websocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.boot:spring-boot-starter-reactor-netty'
 
 	//lombok
 	compileOnly 'org.projectlombok:lombok:1.18.34'

--- a/src/main/java/com/messenger/chatty/domain/member/controller/MyDataController.java
+++ b/src/main/java/com/messenger/chatty/domain/member/controller/MyDataController.java
@@ -1,4 +1,5 @@
 package com.messenger.chatty.domain.member.controller;
+import com.messenger.chatty.domain.workspace.dto.response.MyWorkspaceDto;
 import com.messenger.chatty.global.config.web.AuthenticatedUsername;
 import com.messenger.chatty.domain.member.dto.request.MemberUpdateRequestDto;
 import com.messenger.chatty.domain.member.dto.response.MyProfileDto;
@@ -97,7 +98,7 @@ public class MyDataController {
             ErrorStatus.MEMBER_NOT_FOUND
     })
     @GetMapping("/workspaces")
-    public ApiResponse<List<WorkspaceBriefDto>> getMyWorkspaces(@AuthenticatedUsername String username) {
+    public ApiResponse<List<MyWorkspaceDto>> getMyWorkspaces(@AuthenticatedUsername String username) {
         return ApiResponse.onSuccess(memberService.getMyWorkspaces(username));
     }
 }

--- a/src/main/java/com/messenger/chatty/domain/member/controller/MyDataController.java
+++ b/src/main/java/com/messenger/chatty/domain/member/controller/MyDataController.java
@@ -1,5 +1,7 @@
 package com.messenger.chatty.domain.member.controller;
 import com.messenger.chatty.domain.workspace.dto.response.MyWorkspaceDto;
+import com.messenger.chatty.domain.workspace.entity.Workspace;
+import com.messenger.chatty.domain.workspace.service.WorkspaceService;
 import com.messenger.chatty.global.config.web.AuthenticatedUsername;
 import com.messenger.chatty.domain.member.dto.request.MemberUpdateRequestDto;
 import com.messenger.chatty.domain.member.dto.response.MyProfileDto;
@@ -29,6 +31,7 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 @RestController
 public class MyDataController {
     private final MemberService memberService;
+    private final WorkspaceService workspaceService;
 
     @Operation(summary = "내 프로필 정보 가져오기")
     @ApiErrorCodeExample({
@@ -101,4 +104,19 @@ public class MyDataController {
     public ApiResponse<List<MyWorkspaceDto>> getMyWorkspaces(@AuthenticatedUsername String username) {
         return ApiResponse.onSuccess(memberService.getMyWorkspaces(username));
     }
+
+    @Operation(summary = "워크스페이스에서 나가기",description = "해당 워크스페이스에서 나갑니다.")
+    @ApiErrorCodeExample({
+             MEMBER_NOT_FOUND,
+            MEMBER_NOT_IN_WORKSPACE
+    })
+    @DeleteMapping("/workspaces/{workspaceId}")
+    public ApiResponse<Boolean> deleteWorkspaceProfileImg(@AuthenticatedUsername String username,
+                                                          @PathVariable Long workspaceId){
+        workspaceService.leaveWorkspace(username, workspaceId);
+        return ApiResponse.onSuccess(true);
+    }
+
+
+
 }

--- a/src/main/java/com/messenger/chatty/domain/member/controller/MyDataController.java
+++ b/src/main/java/com/messenger/chatty/domain/member/controller/MyDataController.java
@@ -111,7 +111,7 @@ public class MyDataController {
             MEMBER_NOT_IN_WORKSPACE
     })
     @DeleteMapping("/workspaces/{workspaceId}")
-    public ApiResponse<Boolean> deleteWorkspaceProfileImg(@AuthenticatedUsername String username,
+    public ApiResponse<Boolean> leaveWorkspace(@AuthenticatedUsername String username,
                                                           @PathVariable Long workspaceId){
         workspaceService.leaveWorkspace(username, workspaceId);
         return ApiResponse.onSuccess(true);

--- a/src/main/java/com/messenger/chatty/domain/member/service/MemberService.java
+++ b/src/main/java/com/messenger/chatty/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.messenger.chatty.domain.member.dto.request.MemberJoinRequestDto;
 import com.messenger.chatty.domain.member.dto.request.MemberUpdateRequestDto;
 import com.messenger.chatty.domain.member.dto.response.MemberBriefDto;
 import com.messenger.chatty.domain.member.dto.response.MyProfileDto;
+import com.messenger.chatty.domain.workspace.dto.response.MyWorkspaceDto;
 import com.messenger.chatty.domain.workspace.dto.response.WorkspaceBriefDto;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -24,7 +25,7 @@ public interface MemberService {
     void deleteMeByUsername(String username);
     void deleteMeById(Long id);
 
-    List<WorkspaceBriefDto> getMyWorkspaces(String username);
+    List<MyWorkspaceDto> getMyWorkspaces(String username);
 
     void checkDuplicatedUsername(String username);
 

--- a/src/main/java/com/messenger/chatty/domain/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/messenger/chatty/domain/workspace/controller/WorkspaceController.java
@@ -211,4 +211,7 @@ public class WorkspaceController {
         workspaceService.deleteProfileImage(workspaceId);
         return ApiResponse.onSuccess(true);
     }
+
+
+
 }

--- a/src/main/java/com/messenger/chatty/domain/workspace/dto/response/MyWorkspaceDto.java
+++ b/src/main/java/com/messenger/chatty/domain/workspace/dto/response/MyWorkspaceDto.java
@@ -1,0 +1,19 @@
+package com.messenger.chatty.domain.workspace.dto.response;
+
+import com.messenger.chatty.domain.base.dto.response.BaseResDto;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+
+@Getter
+@SuperBuilder
+@ToString
+public class MyWorkspaceDto extends BaseResDto {
+    private Long id;
+    private String name;
+    private String profileImg;
+    private String description;
+    private String myRole;
+
+}

--- a/src/main/java/com/messenger/chatty/domain/workspace/repository/WorkspaceJoinRepository.java
+++ b/src/main/java/com/messenger/chatty/domain/workspace/repository/WorkspaceJoinRepository.java
@@ -13,6 +13,8 @@ public interface WorkspaceJoinRepository extends JpaRepository<WorkspaceJoin, Lo
     Optional<WorkspaceJoin> findByWorkspaceIdAndMemberUsername(Long workspaceId, String username);
     Optional<WorkspaceJoin> findByWorkspaceIdAndMemberId(Long workspaceId, Long memberId);
 
+    List<WorkspaceJoin> findByMemberId(Long memberId);
+
     @Query("SELECT wj.member FROM WorkspaceJoin wj WHERE wj.workspace.id = :workspaceId")
     List<Member> findMembersByWorkspaceId(@Param("workspaceId") Long workspaceId);
 

--- a/src/main/java/com/messenger/chatty/domain/workspace/service/WorkspaceService.java
+++ b/src/main/java/com/messenger/chatty/domain/workspace/service/WorkspaceService.java
@@ -39,4 +39,6 @@ public interface WorkspaceService {
 
     String uploadProfileImage(Long workspaceId, MultipartFile file);
     void deleteProfileImage(Long workspaceId);
+
+    void leaveWorkspace(String username,Long workspaceId);
 }

--- a/src/main/java/com/messenger/chatty/domain/workspace/service/WorkspaceServiceImpl.java
+++ b/src/main/java/com/messenger/chatty/domain/workspace/service/WorkspaceServiceImpl.java
@@ -244,4 +244,14 @@ public class WorkspaceServiceImpl implements WorkspaceService{
         s3Service.deleteImage(profileImgURI);
         workspace.changeProfile_img(null);
     }
+
+    @Override
+    public void leaveWorkspace(String username, Long workspaceId) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new MemberException(ErrorStatus.MEMBER_NOT_FOUND));
+        WorkspaceJoin workspaceJoin = workspaceJoinRepository.findByWorkspaceIdAndMemberId(workspaceId, member.getId())
+                .orElseThrow(()-> new MemberException(ErrorStatus.MEMBER_NOT_IN_WORKSPACE));
+
+        workspaceJoinRepository.delete(workspaceJoin);
+    }
 }

--- a/src/main/java/com/messenger/chatty/global/service/S3Service.java
+++ b/src/main/java/com/messenger/chatty/global/service/S3Service.java
@@ -57,7 +57,7 @@ public class S3Service {
     private String uploadImageToS3(MultipartFile image) {
         try {
             String originalFilename = image.getOriginalFilename();
-            String s3FileName = UUID.randomUUID().toString().substring(0, 10) + originalFilename;
+            String s3FileName = UUID.randomUUID().toString().substring(0, 10) + originalFilename.substring(0,10);
             InputStream inputStream = image.getInputStream();
             s3Client.putObject(new PutObjectRequest(bucketName, s3FileName, inputStream, null));
             return s3Client.getUrl(bucketName, s3FileName).toString();

--- a/src/main/java/com/messenger/chatty/global/util/CustomConverter.java
+++ b/src/main/java/com/messenger/chatty/global/util/CustomConverter.java
@@ -3,6 +3,7 @@ package com.messenger.chatty.global.util;
 import com.messenger.chatty.domain.channel.dto.response.ChannelBriefDto;
 import com.messenger.chatty.domain.member.dto.response.MemberBriefDto;
 import com.messenger.chatty.domain.member.dto.response.MyProfileDto;
+import com.messenger.chatty.domain.workspace.dto.response.MyWorkspaceDto;
 import com.messenger.chatty.domain.workspace.dto.response.WorkspaceBriefDto;
 import com.messenger.chatty.domain.channel.entity.Channel;
 import com.messenger.chatty.domain.member.entity.Member;
@@ -60,6 +61,17 @@ public class CustomConverter {
                 .profileImg(workspace.getProfile_img())
                 .createdDate(workspace.getCreatedDate())
                 .lastModifiedDate(workspace.getLastModifiedDate()).build();
+    }
+    public static MyWorkspaceDto convertToMyWorkspaceDto(Workspace workspace, String myRole){
+        return MyWorkspaceDto.builder()
+                .id(workspace.getId())
+                .name(workspace.getName())
+                .description(workspace.getDescription())
+                .profileImg(workspace.getProfile_img())
+                .createdDate(workspace.getCreatedDate())
+                .lastModifiedDate(workspace.getLastModifiedDate())
+                .myRole(myRole)
+                .build();
     }
 
     /*public static WorkspaceResponseDto convertWorkspaceToDto(Workspace workspace, List<Channel> channelList, List<Member> memberList ) {

--- a/src/test/java/com/messenger/chatty/service/WorkspaceServiceTest.java
+++ b/src/test/java/com/messenger/chatty/service/WorkspaceServiceTest.java
@@ -6,6 +6,7 @@ import com.messenger.chatty.domain.workspace.dto.request.WorkspaceGenerateReques
 import com.messenger.chatty.domain.workspace.dto.request.WorkspaceUpdateRequestDto;
 import com.messenger.chatty.domain.channel.dto.response.ChannelBriefDto;
 import com.messenger.chatty.domain.member.dto.response.MemberBriefDto;
+import com.messenger.chatty.domain.workspace.dto.response.MyWorkspaceDto;
 import com.messenger.chatty.domain.workspace.dto.response.WorkspaceBriefDto;
 import com.messenger.chatty.domain.workspace.entity.Workspace;
 import com.messenger.chatty.domain.workspace.service.WorkspaceService;
@@ -292,7 +293,7 @@ class WorkspaceServiceTest {
                 .build();
         Long workspaceId = workspaceService.generateWorkspace(generateRequestDto, memberResponse.getUsername());
         //when
-        List<WorkspaceBriefDto> myWorkspaces = memberService.getMyWorkspaces(memberResponse.getUsername());
+        List<MyWorkspaceDto> myWorkspaces = memberService.getMyWorkspaces(memberResponse.getUsername());
         //then
         assertThat(myWorkspaces.size()).isOne();
         assertThat(myWorkspaces.get(0).getName()).isEqualTo(generateRequestDto.getName());


### PR DESCRIPTION
- 내가 참여한 워크스페이스 목록 가져오기 api (/api/me/workspaces) 에서 각 워크스페이스 별로 해당 유저의 role 필드 추가 (MyWorkspaceDto) - 각 워크스페이스에서 해당 유저가 어떤 역할인지 알 필요가 있다는 프론트 측 요구 반영
- 파일명이 지나치게 길어서 DB에 URI 저장 시 문제 -> 길이 제한으로 해결
- 특정 워크스페이스에서 나가기 api 추가