### PR TITLE
fix: change dto to MemberInWorkspaceDto

### DIFF
--- a/src/main/java/com/messenger/chatty/domain/member/dto/response/MemberInWorkspaceDto.java
+++ b/src/main/java/com/messenger/chatty/domain/member/dto/response/MemberInWorkspaceDto.java
@@ -1,16 +1,17 @@
 package com.messenger.chatty.domain.member.dto.response;
+
+
 import com.messenger.chatty.domain.base.dto.response.BaseResDto;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
+import java.time.LocalDateTime;
 
-// 공개될 수 있는 멤버 정보
 @Getter
 @SuperBuilder
 @ToString
-public class MemberBriefDto extends BaseResDto {
-
+public class MemberInWorkspaceDto extends BaseResDto {
     protected Long id;
     protected String username;
     protected String email;
@@ -19,4 +20,5 @@ public class MemberBriefDto extends BaseResDto {
     protected String name;
     protected String nickname;
     protected String introduction;
+    protected LocalDateTime joinDate;
 }

--- a/src/main/java/com/messenger/chatty/domain/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/messenger/chatty/domain/workspace/controller/WorkspaceController.java
@@ -1,4 +1,5 @@
 package com.messenger.chatty.domain.workspace.controller;
+import com.messenger.chatty.domain.member.dto.response.MemberInWorkspaceDto;
 import com.messenger.chatty.domain.workspace.dto.response.WorkspaceBriefDto;
 import com.messenger.chatty.global.config.web.AuthenticatedUsername;
 import com.messenger.chatty.domain.channel.dto.request.ChannelGenerateRequestDto;
@@ -78,7 +79,7 @@ public class WorkspaceController {
             ErrorStatus.WORKSPACE_NOT_FOUND
     })
     @GetMapping("/{workspaceId}/members")
-    public ApiResponse<List<MemberBriefDto>> getMembersOfWorkspace(@PathVariable Long workspaceId){
+    public ApiResponse<List<MemberInWorkspaceDto>> getMembersOfWorkspace(@PathVariable Long workspaceId){
         return ApiResponse.onSuccess(workspaceService.getMembersOfWorkspace(workspaceId));
     }
 
@@ -89,7 +90,7 @@ public class WorkspaceController {
             ErrorStatus.MEMBER_NOT_IN_WORKSPACE
     })
     @GetMapping("/{workspaceId}/members/{memberId}")
-    public ApiResponse<MemberBriefDto> getMemberProfileOfWorkspace(@PathVariable Long workspaceId,
+    public ApiResponse<MemberInWorkspaceDto> getMemberProfileOfWorkspace(@PathVariable Long workspaceId,
                                                                    @PathVariable Long memberId){
         return ApiResponse.onSuccess(workspaceService.getMemberProfileOfWorkspace(workspaceId, memberId));
     }

--- a/src/main/java/com/messenger/chatty/domain/workspace/service/WorkspaceService.java
+++ b/src/main/java/com/messenger/chatty/domain/workspace/service/WorkspaceService.java
@@ -1,5 +1,6 @@
 package com.messenger.chatty.domain.workspace.service;
 
+import com.messenger.chatty.domain.member.dto.response.MemberInWorkspaceDto;
 import com.messenger.chatty.domain.workspace.dto.request.WorkspaceGenerateRequestDto;
 import com.messenger.chatty.domain.workspace.dto.request.WorkspaceUpdateRequestDto;
 import com.messenger.chatty.domain.channel.dto.response.ChannelBriefDto;
@@ -23,9 +24,9 @@ public interface WorkspaceService {
 
     WorkspaceBriefDto  getWorkspaceBriefProfile(Long workspaceId);
 
-    List<MemberBriefDto> getMembersOfWorkspace(Long workspaceId);
+    List<MemberInWorkspaceDto> getMembersOfWorkspace(Long workspaceId);
 
-    MemberBriefDto getMemberProfileOfWorkspace(Long workspaceId, Long memberId);
+    MemberInWorkspaceDto getMemberProfileOfWorkspace(Long workspaceId, Long memberId);
 
     List<ChannelBriefDto> getChannelsOfWorkspace(Long workspaceId);
 

--- a/src/main/java/com/messenger/chatty/domain/workspace/service/WorkspaceServiceImpl.java
+++ b/src/main/java/com/messenger/chatty/domain/workspace/service/WorkspaceServiceImpl.java
@@ -1,6 +1,7 @@
 package com.messenger.chatty.domain.workspace.service;
 import com.messenger.chatty.domain.channel.entity.Channel;
 import com.messenger.chatty.domain.channel.repository.ChannelRepository;
+import com.messenger.chatty.domain.member.dto.response.MemberInWorkspaceDto;
 import com.messenger.chatty.domain.member.entity.Member;
 import com.messenger.chatty.domain.member.repository.MemberRepository;
 import com.messenger.chatty.domain.workspace.entity.Workspace;
@@ -64,26 +65,25 @@ public class WorkspaceServiceImpl implements WorkspaceService{
 
     @Override
     @Transactional(readOnly = true)
-    public List<MemberBriefDto> getMembersOfWorkspace(Long workspaceId) {
+    public List<MemberInWorkspaceDto> getMembersOfWorkspace(Long workspaceId) {
         Workspace workspace = workspaceRepository.findById(workspaceId)
                 .orElseThrow(() ->  new WorkspaceException(ErrorStatus.WORKSPACE_NOT_FOUND));
 
-        //TODO workspace용 멤버 response dto return(해당 멤버의 워크스페이스 내 역할 표시)
         List<Member> members = workspaceJoinRepository.findMembersByWorkspaceId(workspace.getId());
-        members.forEach(member -> {
+
+        return members.stream().map(member -> {
             WorkspaceJoin workspaceJoin = workspaceJoinRepository.
                     findByWorkspaceIdAndMemberUsername(workspaceId, member.getUsername())
                     .orElseThrow(()->new MemberException(ErrorStatus.MEMBER_NOT_IN_WORKSPACE));
-            member.changeRole(workspaceJoin.getRole());
-        });
-
-        return members.stream().map(CustomConverter::convertMemberToBriefDto).toList();
+            return CustomConverter.convertToMemberInWorkspaceDto(member,workspaceJoin.getRole(),workspaceJoin.getCreatedDate() );
+        }
+        ).toList();
 
     }
 
     @Override
     @Transactional(readOnly = true)
-    public MemberBriefDto getMemberProfileOfWorkspace(Long workspaceId, Long memberId) {
+    public MemberInWorkspaceDto getMemberProfileOfWorkspace(Long workspaceId, Long memberId) {
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(ErrorStatus.MEMBER_NOT_FOUND));
@@ -91,9 +91,9 @@ public class WorkspaceServiceImpl implements WorkspaceService{
         WorkspaceJoin workspaceJoin = workspaceJoinRepository.
                 findByWorkspaceIdAndMemberUsername(workspaceId, member.getUsername())
                 .orElseThrow(()->new MemberException(ErrorStatus.MEMBER_NOT_IN_WORKSPACE));
-        member.changeRole(workspaceJoin.getRole());
 
-        return CustomConverter.convertMemberToBriefDto(member);
+
+        return CustomConverter.convertToMemberInWorkspaceDto(member,workspaceJoin.getRole(),workspaceJoin.getCreatedDate());
     }
 
     @Override

--- a/src/main/java/com/messenger/chatty/global/util/CustomConverter.java
+++ b/src/main/java/com/messenger/chatty/global/util/CustomConverter.java
@@ -2,12 +2,15 @@ package com.messenger.chatty.global.util;
 
 import com.messenger.chatty.domain.channel.dto.response.ChannelBriefDto;
 import com.messenger.chatty.domain.member.dto.response.MemberBriefDto;
+import com.messenger.chatty.domain.member.dto.response.MemberInWorkspaceDto;
 import com.messenger.chatty.domain.member.dto.response.MyProfileDto;
 import com.messenger.chatty.domain.workspace.dto.response.MyWorkspaceDto;
 import com.messenger.chatty.domain.workspace.dto.response.WorkspaceBriefDto;
 import com.messenger.chatty.domain.channel.entity.Channel;
 import com.messenger.chatty.domain.member.entity.Member;
 import com.messenger.chatty.domain.workspace.entity.Workspace;
+
+import java.time.LocalDateTime;
 import java.util.List;
 
 
@@ -28,6 +31,21 @@ public class CustomConverter {
                 .lastModifiedDate(member.getLastModifiedDate())
                 .build();
     }
+    public static MemberInWorkspaceDto convertToMemberInWorkspaceDto(Member member,String role, LocalDateTime joinDate){
+        return MemberInWorkspaceDto.builder().id(member.getId())
+                .username(member.getUsername())
+                .email(member.getEmail())
+                .name(member.getName())
+                .role(role)
+                .profileImg(member.getProfile_img())
+                .nickname(member.getNickname())
+                .introduction(member.getIntroduction())
+                .createdDate(member.getCreatedDate())
+                .lastModifiedDate(member.getLastModifiedDate())
+                .joinDate(joinDate)
+                .build();
+    }
+
     public static MyProfileDto convertMemberToDto(Member member,List<Workspace> workspaceList){
         List<WorkspaceBriefDto> workspaceBriefDtoList = workspaceList.stream()
                 .map(CustomConverter::convertWorkspaceToBriefDto).toList();


### PR DESCRIPTION
- 특정 워크스페이스 내의 멤버 목록 가져오기 API와 멤버 프로필 정보 가져오기 API에서, response dto를 
MemberBriefDto-> MemberInWorkspaceDto로 변경 (멤버가 워크스페이스에 참여한 일자를 **joinDate field**로 받기 위함)