### PR TITLE
[Refactor/#28] request of front & change method of getting memberInfo when chat

### DIFF
--- a/src/main/java/com/messenger/chatty/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/messenger/chatty/domain/channel/controller/ChannelController.java
@@ -1,6 +1,6 @@
 package com.messenger.chatty.domain.channel.controller;
 
-import com.messenger.chatty.domain.message.dto.MessageDto;
+import com.messenger.chatty.domain.message.dto.response.MessageResponseDto;
 import com.messenger.chatty.domain.message.service.MessageService;
 import com.messenger.chatty.global.config.web.AuthenticatedUsername;
 import com.messenger.chatty.global.presentation.ApiResponse;
@@ -28,8 +28,8 @@ public class ChannelController {
     @Operation(summary = "메세지 리스트 조회", description = "채널 내 메세지부터 조회하도록 합니다")
     @ApiErrorCodeExample(status = AUTH)
     @GetMapping("/{channelId}")
-    public ApiResponse<List<MessageDto>> getMessageInChannel(@PathVariable Long channelId,
-                                                             @RequestParam(name = "currentPage", defaultValue = "0") int currentPage) {
+    public ApiResponse<List<MessageResponseDto>> getMessageInChannel(@PathVariable Long channelId,
+                                                                     @RequestParam(name = "currentPage", defaultValue = "0") int currentPage) {
         Pageable pageable = PageRequest.of(currentPage, 10);
         return ApiResponse.onSuccess(messageService.getMessages(channelId, pageable));
     }
@@ -37,7 +37,7 @@ public class ChannelController {
     @Operation(summary = "채널 마지막 메세지", description = "채널의 마지막 메세지를 조회합니다.")
     @ApiErrorCodeExample(status = AUTH)
     @GetMapping("/{channelId}/last")
-    public ApiResponse<MessageDto> getLastMessageInChannel(@PathVariable Long channelId){
+    public ApiResponse<MessageResponseDto> getLastMessageInChannel(@PathVariable Long channelId){
         return ApiResponse.onSuccess(messageService.getLastMessageInChannel(channelId));
     }
 

--- a/src/main/java/com/messenger/chatty/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/messenger/chatty/domain/channel/controller/ChannelController.java
@@ -1,5 +1,6 @@
 package com.messenger.chatty.domain.channel.controller;
 
+import com.messenger.chatty.domain.channel.service.ChannelService;
 import com.messenger.chatty.domain.message.dto.response.MessageResponseDto;
 import com.messenger.chatty.domain.message.service.MessageService;
 import com.messenger.chatty.global.config.web.AuthenticatedUsername;
@@ -23,6 +24,7 @@ import static com.messenger.chatty.global.presentation.annotation.api.Predefined
 @RequestMapping("/api/chat")
 public class ChannelController {
     private final MessageService messageService;
+    private final ChannelService channelService;
 
 
     @Operation(summary = "메세지 리스트 조회", description = "채널 내 메세지부터 조회하도록 합니다")
@@ -48,7 +50,8 @@ public class ChannelController {
     @GetMapping("/{channelId}/count")
     public ApiResponse<Long> countUnreadMessageInChannel(@AuthenticatedUsername String username,
                                                          @PathVariable Long channelId) {
-        return ApiResponse.onSuccess(messageService.countUnreadMessage(channelId, username));
+        Long workspaceJoinId = channelService.getWorkspaceJoinId(channelId, username);
+        return ApiResponse.onSuccess(messageService.countUnreadMessage(channelId, workspaceJoinId));
     }
 
     @Operation(summary = "읽은 마지막 메세지 아이디 조회", description = "사용자가 채널에서 읽은 마지막 메세지의 아이디를 조회합니다.")
@@ -58,7 +61,8 @@ public class ChannelController {
     @GetMapping("/{channelId}/read/id")
     public ApiResponse<String> getLastReadMessageId(@AuthenticatedUsername String username,
                                                     @PathVariable Long channelId) {
-        return ApiResponse.onSuccess(messageService.getLastReadMessageId(channelId, username));
+        Long workspaceJoinId = channelService.getWorkspaceJoinId(channelId, username);
+        return ApiResponse.onSuccess(messageService.getLastReadMessageId(channelId, workspaceJoinId));
     }
 
 }

--- a/src/main/java/com/messenger/chatty/domain/channel/dto/response/ChannelBriefDto.java
+++ b/src/main/java/com/messenger/chatty/domain/channel/dto/response/ChannelBriefDto.java
@@ -1,16 +1,15 @@
 package com.messenger.chatty.domain.channel.dto.response;
 
 import com.messenger.chatty.domain.base.dto.response.BaseResDto;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.Data;
 import lombok.experimental.SuperBuilder;
 
-@Getter
+@Data
 @SuperBuilder
-@ToString
 public class ChannelBriefDto extends BaseResDto {
 
     private Long id;
     private String name;
+    private Long unreadCount;
 
 }

--- a/src/main/java/com/messenger/chatty/domain/channel/entity/ChannelAccess.java
+++ b/src/main/java/com/messenger/chatty/domain/channel/entity/ChannelAccess.java
@@ -18,7 +18,7 @@ public class ChannelAccess extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String username;
+    private Long workspaceJoinId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "channel_id")

--- a/src/main/java/com/messenger/chatty/domain/channel/repository/ChannelAccessRepository.java
+++ b/src/main/java/com/messenger/chatty/domain/channel/repository/ChannelAccessRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ChannelAccessRepository extends JpaRepository<ChannelAccess, Long> {
-    Optional<ChannelAccess> findChannelAccessByChannel_IdAndUsername(Long channelId, String username);
+    Optional<ChannelAccess> findChannelAccessByChannel_IdAndWorkspaceJoinId(Long channelId, Long workspaceJoinId);
 
-    boolean existsByChannelIdAndUsername(Long channelId, String username);
+    boolean existsByChannelIdAndWorkspaceJoinId(Long channelId, Long workspaceJoinId);
 }

--- a/src/main/java/com/messenger/chatty/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/messenger/chatty/domain/channel/service/ChannelService.java
@@ -15,6 +15,8 @@ public interface ChannelService {
 
     void deleteChannelInWorkspace(Long workspaceId, Long  channelId);
 
+    Long getWorkspaceJoinId(Long channelId, String username);
+
     boolean validateEnterChannel(Long channelId, String username);
 
     void updateAccessTime(Long channelId, String username, LocalDateTime currentTime);

--- a/src/main/java/com/messenger/chatty/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/messenger/chatty/domain/channel/service/ChannelService.java
@@ -2,6 +2,7 @@ package com.messenger.chatty.domain.channel.service;
 
 import com.messenger.chatty.domain.channel.dto.request.ChannelGenerateRequestDto;
 import com.messenger.chatty.domain.channel.dto.response.ChannelBriefDto;
+import com.messenger.chatty.domain.member.dto.response.MemberBriefDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -27,5 +28,5 @@ public interface ChannelService {
 
     String getUnreadMessageId(Long channelId, String username);
 
-
+    MemberBriefDto getMemberInfoByWorkspace(Long workspaceJoinId);
 }

--- a/src/main/java/com/messenger/chatty/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/messenger/chatty/domain/channel/service/ChannelService.java
@@ -20,13 +20,13 @@ public interface ChannelService {
 
     boolean validateEnterChannel(Long channelId, String username);
 
-    void updateAccessTime(Long channelId, String username, LocalDateTime currentTime);
+    void updateAccessTime(Long channelId, Long workspaceJoinId, LocalDateTime currentTime);
 
-    Long createAccessTime(Long channelId, String username);
+    Long createAccessTime(Long channelId, Long workspaceJoinId);
 
-    boolean hasAccessTime(Long channelId, String username);
+    boolean hasAccessTime(Long channelId, Long workspaceJoinId);
 
-    String getUnreadMessageId(Long channelId, String username);
+    String getUnreadMessageId(Long channelId, Long workspaceJoinId);
 
     MemberBriefDto getMemberInfoByWorkspace(Long workspaceJoinId);
 }

--- a/src/main/java/com/messenger/chatty/domain/channel/service/ChannelServiceImpl.java
+++ b/src/main/java/com/messenger/chatty/domain/channel/service/ChannelServiceImpl.java
@@ -113,9 +113,8 @@ public class ChannelServiceImpl implements ChannelService{
     }
 
     @Override
-    public void updateAccessTime(Long channelId, String username, LocalDateTime currentTime) {
-        ChannelAccess channelAccess = channelAccessRepository
-                .findChannelAccessByChannel_IdAndUsername(channelId, username)
+    public void updateAccessTime(Long channelId, Long workspaceJoinId, LocalDateTime currentTime) {
+        ChannelAccess channelAccess = channelAccessRepository.findChannelAccessByChannel_IdAndWorkspaceJoinId(channelId, workspaceJoinId)
                 .orElseThrow(() -> new ChannelException(ErrorStatus.CHANNEL_ACCESS_NOT_FOUND));
         //accesstime -> lastModifiedTime으로 사용 / 마지막으로 읽은 메세지 아이디 변경
         Pageable pageable = PageRequest.of(0, 1);
@@ -126,18 +125,18 @@ public class ChannelServiceImpl implements ChannelService{
     }
 
     @Override
-    public Long createAccessTime(Long channelId, String username) {
-        return channelAccessRepository.save(builderChannelAccess(username, channelId)).getId();
+    public Long createAccessTime(Long channelId, Long workspaceJoinId) {
+        return channelAccessRepository.save(builderChannelAccess(, channelId)).getId();
     }
 
     @Override
-    public boolean hasAccessTime(Long channelId, String username) {
-        return channelAccessRepository.existsByChannelIdAndUsername(channelId, username);
+    public boolean hasAccessTime(Long channelId, Long workspaceJoinId) {
+        return channelAccessRepository.existsByChannelIdAndWorkspaceJoinId(channelId, workspaceJoinId);
     }
 
     @Override
-    public String getUnreadMessageId(Long channelId, String username) {
-        return channelAccessRepository.findChannelAccessByChannel_IdAndUsername(channelId, username)
+    public String getUnreadMessageId(Long channelId, Long workspaceJoinId) {
+        return channelAccessRepository.findChannelAccessByChannel_IdAndWorkspaceJoinId(channelId, workspaceJoinId)
                 .orElseThrow(() -> new ChannelException(ErrorStatus.CHANNEL_ACCESS_NOT_FOUND))
                 .getLastMessageId();
     }
@@ -149,9 +148,9 @@ public class ChannelServiceImpl implements ChannelService{
         return CustomConverter.convertMemberToBriefDto(workspaceJoin.getMember());
     }
 
-    private ChannelAccess builderChannelAccess(String username, Long channelId) {
+    private ChannelAccess builderChannelAccess(Long workspaceJoinId, Long channelId) {
         return ChannelAccess.builder()
-                .workspaceJoinId(username)
+                .workspaceJoinId(workspaceJoinId)
                 .channel(channelRepository.findById(channelId)
                         .orElseThrow(() -> new ChannelException(ErrorStatus.CHANNEL_NOT_FOUND)))
                 .build();

--- a/src/main/java/com/messenger/chatty/domain/channel/service/ChannelServiceImpl.java
+++ b/src/main/java/com/messenger/chatty/domain/channel/service/ChannelServiceImpl.java
@@ -6,6 +6,7 @@ import com.messenger.chatty.domain.channel.entity.Channel;
 import com.messenger.chatty.domain.channel.entity.ChannelAccess;
 import com.messenger.chatty.domain.channel.repository.ChannelAccessRepository;
 import com.messenger.chatty.domain.channel.repository.ChannelRepository;
+import com.messenger.chatty.domain.member.dto.response.MemberBriefDto;
 import com.messenger.chatty.domain.member.entity.Member;
 import com.messenger.chatty.domain.member.repository.MemberRepository;
 import com.messenger.chatty.domain.message.repository.MessageRepository;
@@ -141,9 +142,16 @@ public class ChannelServiceImpl implements ChannelService{
                 .getLastMessageId();
     }
 
+    @Override
+    public MemberBriefDto getMemberInfoByWorkspace(Long workspaceJoinId) {
+        WorkspaceJoin workspaceJoin = workspaceJoinRepository.findById(workspaceJoinId)
+                .orElseThrow(() -> new WorkspaceException(ErrorStatus.WORKSPACE_NOT_FOUND));
+        return CustomConverter.convertMemberToBriefDto(workspaceJoin.getMember());
+    }
+
     private ChannelAccess builderChannelAccess(String username, Long channelId) {
         return ChannelAccess.builder()
-                .username(username)
+                .workspaceJoinId(username)
                 .channel(channelRepository.findById(channelId)
                         .orElseThrow(() -> new ChannelException(ErrorStatus.CHANNEL_NOT_FOUND)))
                 .build();

--- a/src/main/java/com/messenger/chatty/domain/channel/service/ChannelServiceImpl.java
+++ b/src/main/java/com/messenger/chatty/domain/channel/service/ChannelServiceImpl.java
@@ -126,7 +126,7 @@ public class ChannelServiceImpl implements ChannelService{
 
     @Override
     public Long createAccessTime(Long channelId, Long workspaceJoinId) {
-        return channelAccessRepository.save(builderChannelAccess(, channelId)).getId();
+        return channelAccessRepository.save(builderChannelAccess(workspaceJoinId, channelId)).getId();
     }
 
     @Override

--- a/src/main/java/com/messenger/chatty/domain/channel/service/ChannelServiceImpl.java
+++ b/src/main/java/com/messenger/chatty/domain/channel/service/ChannelServiceImpl.java
@@ -10,6 +10,8 @@ import com.messenger.chatty.domain.member.entity.Member;
 import com.messenger.chatty.domain.member.repository.MemberRepository;
 import com.messenger.chatty.domain.message.repository.MessageRepository;
 import com.messenger.chatty.domain.workspace.entity.Workspace;
+import com.messenger.chatty.domain.workspace.entity.WorkspaceJoin;
+import com.messenger.chatty.domain.workspace.repository.WorkspaceJoinRepository;
 import com.messenger.chatty.domain.workspace.repository.WorkspaceRepository;
 import com.messenger.chatty.global.presentation.ErrorStatus;
 import com.messenger.chatty.global.presentation.exception.custom.ChannelException;
@@ -32,6 +34,7 @@ import java.util.List;
 public class ChannelServiceImpl implements ChannelService{
     private final ChannelRepository channelRepository;
     private final WorkspaceRepository workspaceRepository;
+    private final WorkspaceJoinRepository workspaceJoinRepository;
     private final MemberRepository memberRepository;
     private final MessageRepository messageRepository;
     private final ChannelAccessRepository channelAccessRepository;
@@ -83,6 +86,18 @@ public class ChannelServiceImpl implements ChannelService{
             throw new ChannelException(ErrorStatus.CHANNEL_NOT_IN_WORKSPACE);
 
         channelRepository.delete(channel);
+    }
+
+    @Override
+    public Long getWorkspaceJoinId(Long channelId, String username) {
+        Channel channel = channelRepository.findById(channelId)
+                .orElseThrow(() -> new ChannelException(ErrorStatus.CHANNEL_NOT_FOUND));
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new MemberException(ErrorStatus.MEMBER_NOT_FOUND));
+        WorkspaceJoin workspaceJoin = workspaceJoinRepository
+                .findByWorkspaceIdAndMemberId(channel.getWorkspace().getId(), member.getId())
+                .orElseThrow(() -> new WorkspaceException(ErrorStatus.WORKSPACE_NOT_FOUND));
+        return workspaceJoin.getId();
     }
 
     @Override

--- a/src/main/java/com/messenger/chatty/domain/message/controller/MessageController.java
+++ b/src/main/java/com/messenger/chatty/domain/message/controller/MessageController.java
@@ -34,10 +34,15 @@ public class MessageController {
 
 
     @MessageMapping("chat.message")
-    public void send(MessageDto messageDto, @Header("channelId") String channelIdStr) {
+    public void send(MessageDto messageDto,
+                     @Header("channelId") String channelIdStr,
+                     @Header("workspaceJoinId") String workspaceJoinId,
+                     @Header("nickname") String nickname,
+                     @Header("profileImg") String profileImg) {
         log.info("send");
         if(channelIdStr == null) throw new MessagingException("error");
         messageDto.setRegDate(LocalDateTime.now());
+        messageDto.of(Long.valueOf(workspaceJoinId), profileImg, nickname);
 
         messageService.send(messageDto);
         template.convertAndSend("amq.topic", "channel." + channelIdStr, messageDto);

--- a/src/main/java/com/messenger/chatty/domain/message/controller/MessageController.java
+++ b/src/main/java/com/messenger/chatty/domain/message/controller/MessageController.java
@@ -1,10 +1,9 @@
 package com.messenger.chatty.domain.message.controller;
 
-import com.messenger.chatty.domain.message.dto.MessageDto;
+import com.messenger.chatty.domain.message.dto.request.MessageDto;
 import com.messenger.chatty.domain.message.service.MessageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.handler.annotation.Header;

--- a/src/main/java/com/messenger/chatty/domain/message/dto/request/MessageDto.java
+++ b/src/main/java/com/messenger/chatty/domain/message/dto/request/MessageDto.java
@@ -14,9 +14,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class MessageDto {
     private Long channelId;
-    private String senderNickname;
-    private String senderUsername;
-    private String senderProfileImg;
+    private Long workspaceJoinId;
     private String content;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime regDate;

--- a/src/main/java/com/messenger/chatty/domain/message/dto/request/MessageDto.java
+++ b/src/main/java/com/messenger/chatty/domain/message/dto/request/MessageDto.java
@@ -15,7 +15,15 @@ import java.time.LocalDateTime;
 public class MessageDto {
     private Long channelId;
     private Long workspaceJoinId;
+    private String senderProfileImg;
+    private String senderNickname;
     private String content;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime regDate;
+
+    public void of(Long workspaceJoinId, String senderProfileImg, String senderNickname) {
+        this.workspaceJoinId = workspaceJoinId;
+        this.senderNickname = senderNickname;
+        this.senderProfileImg = senderProfileImg;
+    }
 }

--- a/src/main/java/com/messenger/chatty/domain/message/dto/request/MessageDto.java
+++ b/src/main/java/com/messenger/chatty/domain/message/dto/request/MessageDto.java
@@ -1,19 +1,18 @@
-package com.messenger.chatty.domain.message.dto;
+package com.messenger.chatty.domain.message.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 @Data
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class MessageDto {
-    private String id;
     private Long channelId;
     private String senderNickname;
     private String senderUsername;
@@ -21,5 +20,4 @@ public class MessageDto {
     private String content;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime regDate;
-
 }

--- a/src/main/java/com/messenger/chatty/domain/message/dto/response/MessageListDto.java
+++ b/src/main/java/com/messenger/chatty/domain/message/dto/response/MessageListDto.java
@@ -1,0 +1,21 @@
+package com.messenger.chatty.domain.message.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MessageListDto {
+    @Builder.Default
+    private List<MessageResponseDto> messageResponseDtoList = new ArrayList<>();
+    private boolean isLast;
+    private boolean isHavePoint;
+}

--- a/src/main/java/com/messenger/chatty/domain/message/dto/response/MessageResponseDto.java
+++ b/src/main/java/com/messenger/chatty/domain/message/dto/response/MessageResponseDto.java
@@ -12,4 +12,6 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 public class MessageResponseDto extends MessageDto {
     private String id;
+    private String senderProfileImg;
+    private String senderNickname;
 }

--- a/src/main/java/com/messenger/chatty/domain/message/dto/response/MessageResponseDto.java
+++ b/src/main/java/com/messenger/chatty/domain/message/dto/response/MessageResponseDto.java
@@ -1,0 +1,15 @@
+package com.messenger.chatty.domain.message.dto.response;
+
+import com.messenger.chatty.domain.message.dto.request.MessageDto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MessageResponseDto extends MessageDto {
+    private String id;
+}

--- a/src/main/java/com/messenger/chatty/domain/message/dto/response/MessageResponseDto.java
+++ b/src/main/java/com/messenger/chatty/domain/message/dto/response/MessageResponseDto.java
@@ -1,5 +1,6 @@
 package com.messenger.chatty.domain.message.dto.response;
 
+import com.messenger.chatty.domain.member.entity.Member;
 import com.messenger.chatty.domain.message.dto.request.MessageDto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -12,4 +13,9 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 public class MessageResponseDto extends MessageDto {
     private String id;
+
+    public void fillOutMemberInfo(Member member) {
+        this.setSenderNickname(member.getNickname());
+        this.setSenderProfileImg(member.getProfile_img());
+    }
 }

--- a/src/main/java/com/messenger/chatty/domain/message/dto/response/MessageResponseDto.java
+++ b/src/main/java/com/messenger/chatty/domain/message/dto/response/MessageResponseDto.java
@@ -12,6 +12,4 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 public class MessageResponseDto extends MessageDto {
     private String id;
-    private String senderProfileImg;
-    private String senderNickname;
 }

--- a/src/main/java/com/messenger/chatty/domain/message/entity/Message.java
+++ b/src/main/java/com/messenger/chatty/domain/message/entity/Message.java
@@ -1,6 +1,6 @@
 package com.messenger.chatty.domain.message.entity;
 
-import com.messenger.chatty.domain.message.dto.MessageDto;
+import com.messenger.chatty.domain.message.dto.request.MessageDto;
 import com.messenger.chatty.global.util.TimeUtil;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/messenger/chatty/domain/message/entity/Message.java
+++ b/src/main/java/com/messenger/chatty/domain/message/entity/Message.java
@@ -25,11 +25,7 @@ public class Message {
     private String content;
 
     @NotBlank
-    private String senderNickname;
-    @NotBlank
-    private String senderUsername;
-    @NotBlank
-    private String senderProfileImg;
+    private Long workspaceJoinId;
 
     @NotNull
     private Long sendTime;
@@ -37,10 +33,8 @@ public class Message {
     public static Message of(MessageDto messageDto) {
         return Message.builder()
                 .channelId(messageDto.getChannelId())
+                .workspaceJoinId(messageDto.getWorkspaceJoinId())
                 .content(messageDto.getContent())
-                .senderNickname(messageDto.getSenderNickname())
-                .senderUsername(messageDto.getSenderUsername())
-                .senderProfileImg(messageDto.getSenderProfileImg())
                 .sendTime(TimeUtil.convertTimeTypeToLong(messageDto.getRegDate()))
                 .build();
     }

--- a/src/main/java/com/messenger/chatty/domain/message/repository/MessageRepository.java
+++ b/src/main/java/com/messenger/chatty/domain/message/repository/MessageRepository.java
@@ -5,7 +5,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface MessageRepository extends MongoRepository<Message, Long> {
 
     @Query(value = "{'channelId': ?0, 'sendTime': {$gt: ?1}}", sort = "{'sendTime': -1}")

--- a/src/main/java/com/messenger/chatty/domain/message/service/MessageService.java
+++ b/src/main/java/com/messenger/chatty/domain/message/service/MessageService.java
@@ -10,13 +10,13 @@ public interface MessageService {
 
     String send(MessageDto messageDto);
 
-    List<MessageResponseDto> getMessageByLastAccessTime(Long channelId, String username, Pageable pageable);
+    List<MessageResponseDto> getMessageByLastAccessTime(Long channelId, Long workspaceJoinId, Pageable pageable);
 
-    Long countUnreadMessage(Long channelId, String username);
+    Long countUnreadMessage(Long channelId, Long workspaceJoinId);
 
     List<MessageResponseDto> getMessages(Long channelId, Pageable pageable);
 
-    String getLastReadMessageId(Long channelId, String username);
+    String getLastReadMessageId(Long channelId, Long workspaceJoinId);
 
     MessageResponseDto getLastMessageInChannel(Long channelId);
 }

--- a/src/main/java/com/messenger/chatty/domain/message/service/MessageService.java
+++ b/src/main/java/com/messenger/chatty/domain/message/service/MessageService.java
@@ -1,6 +1,7 @@
 package com.messenger.chatty.domain.message.service;
 
 import com.messenger.chatty.domain.message.dto.request.MessageDto;
+import com.messenger.chatty.domain.message.dto.response.MessageListDto;
 import com.messenger.chatty.domain.message.dto.response.MessageResponseDto;
 import org.springframework.data.domain.Pageable;
 
@@ -14,7 +15,7 @@ public interface MessageService {
 
     Long countUnreadMessage(Long channelId, Long workspaceJoinId);
 
-    List<MessageResponseDto> getMessages(Long channelId, Pageable pageable);
+    MessageListDto getMessages(Long channelId, Pageable pageable);
 
     String getLastReadMessageId(Long channelId, Long workspaceJoinId);
 

--- a/src/main/java/com/messenger/chatty/domain/message/service/MessageService.java
+++ b/src/main/java/com/messenger/chatty/domain/message/service/MessageService.java
@@ -1,6 +1,7 @@
 package com.messenger.chatty.domain.message.service;
 
-import com.messenger.chatty.domain.message.dto.MessageDto;
+import com.messenger.chatty.domain.message.dto.request.MessageDto;
+import com.messenger.chatty.domain.message.dto.response.MessageResponseDto;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -9,13 +10,13 @@ public interface MessageService {
 
     String send(MessageDto messageDto);
 
-    List<MessageDto> getMessageByLastAccessTime(Long channelId, String username, Pageable pageable);
+    List<MessageResponseDto> getMessageByLastAccessTime(Long channelId, String username, Pageable pageable);
 
     Long countUnreadMessage(Long channelId, String username);
 
-    List<MessageDto> getMessages(Long channelId, Pageable pageable);
+    List<MessageResponseDto> getMessages(Long channelId, Pageable pageable);
 
     String getLastReadMessageId(Long channelId, String username);
 
-    MessageDto getLastMessageInChannel(Long channelId);
+    MessageResponseDto getLastMessageInChannel(Long channelId);
 }

--- a/src/main/java/com/messenger/chatty/domain/message/service/MessageServiceImpl.java
+++ b/src/main/java/com/messenger/chatty/domain/message/service/MessageServiceImpl.java
@@ -53,13 +53,13 @@ public class MessageServiceImpl implements MessageService{
     @Transactional(readOnly = true)
     @Override
     public Long countUnreadMessage(Long channelId, Long workspaceJoinId) {
-        ChannelAccess channelAccess = channelAccessRepository.findChannelAccessByChannel_IdAndWorkspaceJoinId(channelId, workspaceJoinId)
-                .orElseThrow(() -> new ChannelException(ErrorStatus.CHANNEL_ACCESS_NOT_FOUND));
-
-        return messageRepository.countByChatRoomIdAndSendTimeAfter(
-                channelId,
-                TimeUtil.convertTimeTypeToLong(channelAccess.getLastModifiedDate())
-        );
+        return channelAccessRepository
+                .findChannelAccessByChannel_IdAndWorkspaceJoinId(channelId, workspaceJoinId)
+                .map(access -> messageRepository.countByChatRoomIdAndSendTimeAfter(
+                        channelId,
+                        TimeUtil.convertTimeTypeToLong(access.getLastModifiedDate())
+                ))
+                .orElse(0L);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/messenger/chatty/domain/message/service/MessageServiceImpl.java
+++ b/src/main/java/com/messenger/chatty/domain/message/service/MessageServiceImpl.java
@@ -2,7 +2,8 @@ package com.messenger.chatty.domain.message.service;
 
 import com.messenger.chatty.domain.channel.entity.ChannelAccess;
 import com.messenger.chatty.domain.channel.repository.ChannelAccessRepository;
-import com.messenger.chatty.domain.message.dto.MessageDto;
+import com.messenger.chatty.domain.message.dto.request.MessageDto;
+import com.messenger.chatty.domain.message.dto.response.MessageResponseDto;
 import com.messenger.chatty.domain.message.entity.Message;
 import com.messenger.chatty.domain.message.repository.MessageRepository;
 import com.messenger.chatty.global.presentation.ErrorStatus;
@@ -35,7 +36,7 @@ public class MessageServiceImpl implements MessageService{
 
     @Transactional(readOnly = true)
     @Override
-    public List<MessageDto> getMessageByLastAccessTime(Long channelId, String username, Pageable pageable) {
+    public List<MessageResponseDto> getMessageByLastAccessTime(Long channelId, String username, Pageable pageable) {
         ChannelAccess channelAccess = channelAccessRepository.findChannelAccessByChannel_IdAndUsername(channelId, username)
                 .orElseThrow(() -> new ChannelException(ErrorStatus.CHANNEL_ACCESS_NOT_FOUND));
         Page<Message> messages = messageRepository
@@ -59,7 +60,7 @@ public class MessageServiceImpl implements MessageService{
     }
 
     @Override
-    public List<MessageDto> getMessages(Long channelId, Pageable pageable) {
+    public List<MessageResponseDto> getMessages(Long channelId, Pageable pageable) {
         Page<Message> messages = messageRepository.findMessages(channelId, pageable);
         return CustomConverter.convertMessageResponse(messages);
     }
@@ -74,7 +75,7 @@ public class MessageServiceImpl implements MessageService{
     }
 
     @Override
-    public MessageDto getLastMessageInChannel(Long channelId) {
+    public MessageResponseDto getLastMessageInChannel(Long channelId) {
         Pageable pageable = PageRequest.of(0, 1);
         return CustomConverter.convertMessageResponse(
                         messageRepository.findMessages(channelId, pageable)

--- a/src/main/java/com/messenger/chatty/domain/message/service/MessageServiceImpl.java
+++ b/src/main/java/com/messenger/chatty/domain/message/service/MessageServiceImpl.java
@@ -36,8 +36,8 @@ public class MessageServiceImpl implements MessageService{
 
     @Transactional(readOnly = true)
     @Override
-    public List<MessageResponseDto> getMessageByLastAccessTime(Long channelId, String username, Pageable pageable) {
-        ChannelAccess channelAccess = channelAccessRepository.findChannelAccessByChannel_IdAndUsername(channelId, username)
+    public List<MessageResponseDto> getMessageByLastAccessTime(Long channelId, Long workspaceJoinId, Pageable pageable) {
+        ChannelAccess channelAccess = channelAccessRepository.findChannelAccessByChannel_IdAndWorkspaceJoinId(channelId, workspaceJoinId)
                 .orElseThrow(() -> new ChannelException(ErrorStatus.CHANNEL_ACCESS_NOT_FOUND));
         Page<Message> messages = messageRepository
                 .findMessagesByChatRoomIdAfterMemberDisconnectTime(
@@ -49,8 +49,8 @@ public class MessageServiceImpl implements MessageService{
 
     @Transactional(readOnly = true)
     @Override
-    public Long countUnreadMessage(Long channelId, String username) {
-        ChannelAccess channelAccess = channelAccessRepository.findChannelAccessByChannel_IdAndUsername(channelId, username)
+    public Long countUnreadMessage(Long channelId, Long workspaceJoinId) {
+        ChannelAccess channelAccess = channelAccessRepository.findChannelAccessByChannel_IdAndWorkspaceJoinId(channelId, workspaceJoinId)
                 .orElseThrow(() -> new ChannelException(ErrorStatus.CHANNEL_ACCESS_NOT_FOUND));
 
         return messageRepository.countByChatRoomIdAndSendTimeAfter(
@@ -67,9 +67,9 @@ public class MessageServiceImpl implements MessageService{
 
     @Transactional(readOnly = true)
     @Override
-    public String getLastReadMessageId(Long channelId, String username) {
+    public String getLastReadMessageId(Long channelId, Long workspaceJoinId) {
         ChannelAccess channelAccess = channelAccessRepository
-                .findChannelAccessByChannel_IdAndUsername(channelId, username)
+                .findChannelAccessByChannel_IdAndWorkspaceJoinId(channelId, workspaceJoinId)
                 .orElseThrow(() -> new ChannelException(ErrorStatus.CHANNEL_ACCESS_NOT_FOUND));
         return channelAccess.getLastMessageId();
     }

--- a/src/main/java/com/messenger/chatty/domain/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/messenger/chatty/domain/workspace/controller/WorkspaceController.java
@@ -1,4 +1,5 @@
 package com.messenger.chatty.domain.workspace.controller;
+import com.messenger.chatty.domain.message.service.MessageService;
 import com.messenger.chatty.domain.workspace.dto.response.WorkspaceBriefDto;
 import com.messenger.chatty.global.config.web.AuthenticatedUsername;
 import com.messenger.chatty.domain.channel.dto.request.ChannelGenerateRequestDto;
@@ -31,6 +32,7 @@ import static com.messenger.chatty.global.presentation.ErrorStatus.IO_EXCEPTION_
 public class WorkspaceController {
     private final ChannelService channelService;
     private final WorkspaceService workspaceService;
+    private final MessageService messageService;
 
 
     @Operation(summary = "워크스페이스 생성하기")
@@ -69,8 +71,13 @@ public class WorkspaceController {
             ErrorStatus.WORKSPACE_NOT_FOUND
     })
     @GetMapping("/{workspaceId}/channels")
-    public ApiResponse<List<ChannelBriefDto>> getChannelsOfWorkspace(@PathVariable Long workspaceId){
-        return ApiResponse.onSuccess(workspaceService.getChannelsOfWorkspace(workspaceId));
+    public ApiResponse<List<ChannelBriefDto>> getChannelsOfWorkspace(@AuthenticatedUsername String username,
+                                                                     @PathVariable Long workspaceId){
+        List<ChannelBriefDto> channelBriefDtoList = workspaceService.getChannelsOfWorkspace(workspaceId);
+        channelBriefDtoList.forEach(dto -> dto.setUnreadCount(
+                messageService.countUnreadMessage(dto.getId(), username)
+        ));
+        return ApiResponse.onSuccess(channelBriefDtoList);
     }
 
     @Operation(summary = "워크스페이스의 멤버 리스트 가져오기")

--- a/src/main/java/com/messenger/chatty/domain/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/messenger/chatty/domain/workspace/controller/WorkspaceController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -25,6 +26,7 @@ import java.util.List;
 import static com.messenger.chatty.global.presentation.ErrorStatus.*;
 import static com.messenger.chatty.global.presentation.ErrorStatus.IO_EXCEPTION_ON_IMAGE_DELETE;
 
+@Slf4j
 @Tag(name = "WORKSPACE API", description = "워크스페이스와 관련된 핵심적인 API 들입니다.")
 @RequestMapping("/api/workspace")
 @RequiredArgsConstructor
@@ -71,11 +73,14 @@ public class WorkspaceController {
             ErrorStatus.WORKSPACE_NOT_FOUND
     })
     @GetMapping("/{workspaceId}/channels")
-    public ApiResponse<List<ChannelBriefDto>> getChannelsOfWorkspace(@PathVariable Long workspaceId){
+    public ApiResponse<List<ChannelBriefDto>> getChannelsOfWorkspace(@AuthenticatedUsername String username,
+                                                                     @PathVariable Long workspaceId){
         List<ChannelBriefDto> channelBriefDtoList = workspaceService.getChannelsOfWorkspace(workspaceId);
-        channelBriefDtoList.forEach(dto -> dto.setUnreadCount(
-                messageService.countUnreadMessage(dto.getId(), dto.getId())
-        ));
+        channelBriefDtoList.forEach(dto ->
+            dto.setUnreadCount(
+                    messageService.countUnreadMessage(dto.getId(), channelService.getWorkspaceJoinId(dto.getId(), username))
+            )
+        );
         return ApiResponse.onSuccess(channelBriefDtoList);
     }
 

--- a/src/main/java/com/messenger/chatty/domain/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/messenger/chatty/domain/workspace/controller/WorkspaceController.java
@@ -71,11 +71,10 @@ public class WorkspaceController {
             ErrorStatus.WORKSPACE_NOT_FOUND
     })
     @GetMapping("/{workspaceId}/channels")
-    public ApiResponse<List<ChannelBriefDto>> getChannelsOfWorkspace(@AuthenticatedUsername String username,
-                                                                     @PathVariable Long workspaceId){
+    public ApiResponse<List<ChannelBriefDto>> getChannelsOfWorkspace(@PathVariable Long workspaceId){
         List<ChannelBriefDto> channelBriefDtoList = workspaceService.getChannelsOfWorkspace(workspaceId);
         channelBriefDtoList.forEach(dto -> dto.setUnreadCount(
-                messageService.countUnreadMessage(dto.getId(), username)
+                messageService.countUnreadMessage(dto.getId(), dto.getId())
         ));
         return ApiResponse.onSuccess(channelBriefDtoList);
     }

--- a/src/main/java/com/messenger/chatty/domain/workspace/service/WorkspaceServiceImpl.java
+++ b/src/main/java/com/messenger/chatty/domain/workspace/service/WorkspaceServiceImpl.java
@@ -3,6 +3,7 @@ import com.messenger.chatty.domain.channel.entity.Channel;
 import com.messenger.chatty.domain.channel.repository.ChannelRepository;
 import com.messenger.chatty.domain.member.entity.Member;
 import com.messenger.chatty.domain.member.repository.MemberRepository;
+import com.messenger.chatty.domain.message.repository.MessageRepository;
 import com.messenger.chatty.domain.workspace.entity.Workspace;
 import com.messenger.chatty.domain.workspace.entity.WorkspaceJoin;
 import com.messenger.chatty.domain.workspace.dto.request.WorkspaceGenerateRequestDto;
@@ -41,6 +42,7 @@ public class WorkspaceServiceImpl implements WorkspaceService{
     private final ChannelRepository channelRepository;
     private final InvitationCodeGenerator invitationCodeGenerator;
     private final WorkspaceJoinRepository workspaceJoinRepository;
+    private final MessageRepository messageRepository;
 
 
 

--- a/src/main/java/com/messenger/chatty/global/config/mongo/MongoConfig.java
+++ b/src/main/java/com/messenger/chatty/global/config/mongo/MongoConfig.java
@@ -1,33 +1,33 @@
-//package com.messenger.chatty.global.config.mongo;
-//
-//import com.mongodb.client.MongoClient;
-//import com.mongodb.client.MongoClients;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.beans.factory.annotation.Value;
-//import org.springframework.boot.autoconfigure.mongo.MongoProperties;
-//import org.springframework.context.annotation.Bean;
-//import org.springframework.context.annotation.Configuration;
-//import org.springframework.data.mongodb.core.MongoTemplate;
-//import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
-//
-//@RequiredArgsConstructor
-//@EnableMongoRepositories(basePackages = "com.messenger.chatty")
-//@Configuration
-//public class MongoConfig {
-//
-//    @Value("${mongodb.client}")
-//    private String MONGO_DB_CLIENT;
-//    @Value("${mongodb.name}")
-//    private String MONGO_DB_NAME;
-//
-//    @Bean
-//    public MongoClient mongoClient() {
-//        return MongoClients.create(MONGO_DB_CLIENT);
-//    }
-//
-//    @Bean
-//    public MongoTemplate mongoTemplate() {
-//        return new MongoTemplate(mongoClient(), MONGO_DB_NAME);
-//    }
-//
-//}
+package com.messenger.chatty.global.config.mongo;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+//TODO comment out
+@RequiredArgsConstructor
+@EnableMongoRepositories(basePackages = "com.messenger.chatty")
+@Configuration
+public class MongoConfig {
+
+    @Value("${mongodb.client}")
+    private String MONGO_DB_CLIENT;
+    @Value("${mongodb.name}")
+    private String MONGO_DB_NAME;
+
+    @Bean
+    public MongoClient mongoClient() {
+        return MongoClients.create(MONGO_DB_CLIENT);
+    }
+
+    @Bean
+    public MongoTemplate mongoTemplate() {
+        return new MongoTemplate(mongoClient(), MONGO_DB_NAME);
+    }
+
+}

--- a/src/main/java/com/messenger/chatty/global/config/mongo/MongoConfig.java
+++ b/src/main/java/com/messenger/chatty/global/config/mongo/MongoConfig.java
@@ -1,33 +1,33 @@
-package com.messenger.chatty.global.config.mongo;
-
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoClients;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
-
-//TODO comment out
-@RequiredArgsConstructor
-@EnableMongoRepositories(basePackages = "com.messenger.chatty")
-@Configuration
-public class MongoConfig {
-
-    @Value("${mongodb.client}")
-    private String MONGO_DB_CLIENT;
-    @Value("${mongodb.name}")
-    private String MONGO_DB_NAME;
-
-    @Bean
-    public MongoClient mongoClient() {
-        return MongoClients.create(MONGO_DB_CLIENT);
-    }
-
-    @Bean
-    public MongoTemplate mongoTemplate() {
-        return new MongoTemplate(mongoClient(), MONGO_DB_NAME);
-    }
-
-}
+//package com.messenger.chatty.global.config.mongo;
+//
+//import com.mongodb.client.MongoClient;
+//import com.mongodb.client.MongoClients;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.data.mongodb.core.MongoTemplate;
+//import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+//
+////TODO comment out
+//@RequiredArgsConstructor
+//@EnableMongoRepositories(basePackages = "com.messenger.chatty")
+//@Configuration
+//public class MongoConfig {
+//
+//    @Value("${mongodb.client}")
+//    private String MONGO_DB_CLIENT;
+//    @Value("${mongodb.name}")
+//    private String MONGO_DB_NAME;
+//
+//    @Bean
+//    public MongoClient mongoClient() {
+//        return MongoClients.create(MONGO_DB_CLIENT);
+//    }
+//
+//    @Bean
+//    public MongoTemplate mongoTemplate() {
+//        return new MongoTemplate(mongoClient(), MONGO_DB_NAME);
+//    }
+//
+//}

--- a/src/main/java/com/messenger/chatty/global/config/stomp/ChatPreHandler.java
+++ b/src/main/java/com/messenger/chatty/global/config/stomp/ChatPreHandler.java
@@ -2,8 +2,8 @@ package com.messenger.chatty.global.config.stomp;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.messenger.chatty.domain.channel.service.ChannelService;
+import com.messenger.chatty.domain.member.dto.response.MemberBriefDto;
 import com.messenger.chatty.global.presentation.ErrorStatus;
-import com.messenger.chatty.global.presentation.exception.GeneralException;
 import com.messenger.chatty.global.presentation.exception.custom.StompMessagingException;
 import com.messenger.chatty.global.util.WebSocketUtil;
 import com.messenger.chatty.security.service.AuthService;
@@ -18,8 +18,6 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
-
-import java.time.LocalDateTime;
 
 @Order(Ordered.HIGHEST_PRECEDENCE + 99)
 @Component
@@ -52,6 +50,7 @@ public class ChatPreHandler implements ChannelInterceptor {
                     Long workspaceJoinId = channelService.getWorkspaceJoinId(channelId, username);
 
                     headerAccessor.getSessionAttributes().put("workspaceJoinId", workspaceJoinId);
+                    headerAccessor.getSessionAttributes().put("channelId", channelId);
 
 
                     log.info("CONNECT: username={}, channelId={}", username, channelId);
@@ -61,39 +60,18 @@ public class ChatPreHandler implements ChannelInterceptor {
                 }
             }
             case SUBSCRIBE -> {
-                String username = (String) headerAccessor.getSessionAttributes().get("username");
-                Long channelId = (Long) headerAccessor.getSessionAttributes().get("channelId");
-                if (username == null || channelId == null) {
+                Long workspaceJoinId = (Long) headerAccessor.getSessionAttributes().get("workspaceJoinId");
+                if (workspaceJoinId == null) {
                     throw new StompMessagingException(ErrorStatus.REQUEST_PARAM_IS_NULL);
                 }
-
-                boolean validated;
-                try{
-                    validated = channelService.validateEnterChannel(channelId, username);
-                }
-                catch (GeneralException e){
-                    throw new StompMessagingException(ErrorStatus.INVALID_REQUEST_PARAM);
-                }
-
-                headerAccessor.getSessionAttributes().put("validated", validated);
-                if (!validated) {
-                    log.info("SUBSCRIBE: Validation failed for username={}, channelId={}", username, channelId);
-                    throw new StompMessagingException(ErrorStatus.CHANNEL_ACCESS_DENIAL);
-                }
-                log.info("SUBSCRIBE: username={}, channelId={}", username, channelId);
+                MemberBriefDto memberBriefDto = channelService.getMemberInfoByWorkspace(workspaceJoinId);
+                headerAccessor.getSessionAttributes().put("nickname", memberBriefDto.getNickname());
+                headerAccessor.getSessionAttributes().put("profileImg", memberBriefDto.getProfileImg());
 
             }
             case DISCONNECT -> {
                 try{
-                    if ((Boolean) headerAccessor.getSessionAttributes().get("validated")) {
-                        String username = (String) headerAccessor.getSessionAttributes().get("username");
-                        Long channelId = (Long) headerAccessor.getSessionAttributes().get("channelId");
-                        if (!channelService.hasAccessTime(channelId, username)) {
-                            channelService.createAccessTime(channelId, username);
-                        }
-                        channelService.updateAccessTime(channelId,username, LocalDateTime.now());
 
-                    }
                 }
                 catch (RuntimeException e){
                     throw new StompMessagingException(ErrorStatus.INVALID_DISCONNECT_LOGIC);

--- a/src/main/java/com/messenger/chatty/global/config/stomp/ChatPreHandler.java
+++ b/src/main/java/com/messenger/chatty/global/config/stomp/ChatPreHandler.java
@@ -19,6 +19,8 @@ import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
+
 @Order(Ordered.HIGHEST_PRECEDENCE + 99)
 @Component
 @RequiredArgsConstructor
@@ -71,7 +73,12 @@ public class ChatPreHandler implements ChannelInterceptor {
             }
             case DISCONNECT -> {
                 try{
-
+                    Long workspaceJoinId = (Long) headerAccessor.getSessionAttributes().get("workspaceJoinId");
+                    Long channelId = (Long) headerAccessor.getSessionAttributes().get("channelId");
+                    if (!channelService.hasAccessTime(channelId, workspaceJoinId)) {
+                        channelService.createAccessTime(channelId, workspaceJoinId);
+                    }
+                    channelService.updateAccessTime(channelId, workspaceJoinId, LocalDateTime.now());
                 }
                 catch (RuntimeException e){
                     throw new StompMessagingException(ErrorStatus.INVALID_DISCONNECT_LOGIC);

--- a/src/main/java/com/messenger/chatty/global/config/stomp/ChatPreHandler.java
+++ b/src/main/java/com/messenger/chatty/global/config/stomp/ChatPreHandler.java
@@ -4,7 +4,6 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.messenger.chatty.domain.channel.service.ChannelService;
 import com.messenger.chatty.global.presentation.ErrorStatus;
 import com.messenger.chatty.global.presentation.exception.GeneralException;
-import com.messenger.chatty.global.presentation.exception.custom.MemberException;
 import com.messenger.chatty.global.presentation.exception.custom.StompMessagingException;
 import com.messenger.chatty.global.util.WebSocketUtil;
 import com.messenger.chatty.security.service.AuthService;
@@ -14,7 +13,6 @@ import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
@@ -50,9 +48,11 @@ public class ChatPreHandler implements ChannelInterceptor {
                     DecodedJWT decodedJWT = authService.decodeToken(accessToken, "access");
                     String username = decodedJWT.getSubject();
                     Long channelId = WebSocketUtil.getChannelId(headerAccessor);
+                    //TODO username & channelId -> workspaceJoinId
+                    Long workspaceJoinId = channelService.getWorkspaceJoinId(channelId, username);
 
-                    headerAccessor.getSessionAttributes().put("username", username);
-                    headerAccessor.getSessionAttributes().put("channelId", channelId);
+                    headerAccessor.getSessionAttributes().put("workspaceJoinId", workspaceJoinId);
+
 
                     log.info("CONNECT: username={}, channelId={}", username, channelId);
                 } catch (RuntimeException e) {

--- a/src/main/java/com/messenger/chatty/global/config/stomp/ChatPreHandler.java
+++ b/src/main/java/com/messenger/chatty/global/config/stomp/ChatPreHandler.java
@@ -48,14 +48,11 @@ public class ChatPreHandler implements ChannelInterceptor {
                     DecodedJWT decodedJWT = authService.decodeToken(accessToken, "access");
                     String username = decodedJWT.getSubject();
                     Long channelId = WebSocketUtil.getChannelId(headerAccessor);
-                    //TODO username & channelId -> workspaceJoinId
                     Long workspaceJoinId = channelService.getWorkspaceJoinId(channelId, username);
 
                     headerAccessor.getSessionAttributes().put("workspaceJoinId", workspaceJoinId);
                     headerAccessor.getSessionAttributes().put("channelId", channelId);
 
-
-                    log.info("CONNECT: username={}, channelId={}", username, channelId);
                 } catch (RuntimeException e) {
                     log.error("Failed to process CONNECT command", e);
                     throw new StompMessagingException(ErrorStatus.AUTH_INVALID_TOKEN);
@@ -68,8 +65,9 @@ public class ChatPreHandler implements ChannelInterceptor {
                 }
                 MemberBriefDto memberBriefDto = channelService.getMemberInfoByWorkspace(workspaceJoinId);
                 headerAccessor.getSessionAttributes().put("nickname", memberBriefDto.getNickname());
-                headerAccessor.getSessionAttributes().put("profileImg", memberBriefDto.getProfileImg());
-
+                if (memberBriefDto.getProfileImg() != null) {
+                    headerAccessor.getSessionAttributes().put("profileImg", memberBriefDto.getProfileImg());
+                }
             }
             case DISCONNECT -> {
                 try{
@@ -89,6 +87,7 @@ public class ChatPreHandler implements ChannelInterceptor {
             case UNSUBSCRIBE -> {
             }
             case SEND -> {
+
             }
             case ACK -> {
             }

--- a/src/main/java/com/messenger/chatty/global/config/stomp/StompConfig.java
+++ b/src/main/java/com/messenger/chatty/global/config/stomp/StompConfig.java
@@ -33,13 +33,12 @@ public class StompConfig implements WebSocketMessageBrokerConfigurer {
         registry.setApplicationDestinationPrefixes("/pub");
 
         //registry.enableSimpleBroker("/sub");
-        registry.enableStompBrokerRelay("/queue", "/topic", "/exchange", "/amq/queue");
-        //TODO remove comment out
-//                .setRelayPort(61613)
-//                .setVirtualHost("/")
-//                .setClientLogin("guest")
-//                .setClientPasscode("guest")
-//                .setRelayHost("rabbitmq"); // for docker internal network*/
+        registry.enableStompBrokerRelay("/queue", "/topic", "/exchange", "/amq/queue")
+                .setRelayPort(61613)
+                .setVirtualHost("/")
+                .setClientLogin("guest")
+                .setClientPasscode("guest")
+                .setRelayHost("rabbitmq"); // for docker internal network*/
 
     }
 

--- a/src/main/java/com/messenger/chatty/global/config/stomp/StompConfig.java
+++ b/src/main/java/com/messenger/chatty/global/config/stomp/StompConfig.java
@@ -33,12 +33,13 @@ public class StompConfig implements WebSocketMessageBrokerConfigurer {
         registry.setApplicationDestinationPrefixes("/pub");
 
         //registry.enableSimpleBroker("/sub");
-        registry.enableStompBrokerRelay("/queue", "/topic", "/exchange", "/amq/queue")
-                .setRelayPort(61613)
-                .setVirtualHost("/")
-                .setClientLogin("guest")
-                .setClientPasscode("guest")
-                .setRelayHost("rabbitmq"); // for docker internal network*/
+        registry.enableStompBrokerRelay("/queue", "/topic", "/exchange", "/amq/queue");
+        //TODO remove comment out
+//                .setRelayPort(61613)
+//                .setVirtualHost("/")
+//                .setClientLogin("guest")
+//                .setClientPasscode("guest")
+//                .setRelayHost("rabbitmq"); // for docker internal network*/
 
     }
 

--- a/src/main/java/com/messenger/chatty/global/util/CustomConverter.java
+++ b/src/main/java/com/messenger/chatty/global/util/CustomConverter.java
@@ -88,9 +88,6 @@ public class CustomConverter {
     public static List<MessageResponseDto> convertMessageResponse(Page<Message> messages) {
          return messages.getContent().stream()
                 .map(message -> MessageResponseDto.builder()
-                        .senderProfileImg(message.getSenderProfileImg())
-                        .senderUsername(message.getSenderUsername())
-                        .senderNickname(message.getSenderNickname())
                         .regDate(TimeUtil.convertTimeTypeToLocalDateTime(message.getSendTime()))
                         .content(message.getContent())
                         .id(message.getId())

--- a/src/main/java/com/messenger/chatty/global/util/CustomConverter.java
+++ b/src/main/java/com/messenger/chatty/global/util/CustomConverter.java
@@ -92,6 +92,7 @@ public class CustomConverter {
                         .content(message.getContent())
                         .id(message.getId())
                         .channelId(message.getChannelId())
+                        .workspaceJoinId(message.getWorkspaceJoinId())
                         .build())
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/messenger/chatty/global/util/CustomConverter.java
+++ b/src/main/java/com/messenger/chatty/global/util/CustomConverter.java
@@ -5,12 +5,9 @@ import com.messenger.chatty.domain.channel.entity.Channel;
 import com.messenger.chatty.domain.member.dto.response.MemberBriefDto;
 import com.messenger.chatty.domain.member.dto.response.MyProfileDto;
 import com.messenger.chatty.domain.member.entity.Member;
-import com.messenger.chatty.domain.message.dto.MessageDto;
+import com.messenger.chatty.domain.message.dto.response.MessageResponseDto;
 import com.messenger.chatty.domain.message.entity.Message;
 import com.messenger.chatty.domain.workspace.dto.response.WorkspaceBriefDto;
-import com.messenger.chatty.domain.workspace.dto.response.WorkspaceResponseDto;
-import com.messenger.chatty.domain.channel.entity.Channel;
-import com.messenger.chatty.domain.member.entity.Member;
 import com.messenger.chatty.domain.workspace.entity.Workspace;
 import org.springframework.data.domain.Page;
 
@@ -88,10 +85,10 @@ public class CustomConverter {
     }
 */
 
-    public static List<MessageDto> convertMessageResponse(Page<Message> messages) {
+    public static List<MessageResponseDto> convertMessageResponse(Page<Message> messages) {
          return messages.getContent().stream()
-                .map(message -> MessageDto.builder()
-                        .senderProfileImg(message.getId())
+                .map(message -> MessageResponseDto.builder()
+                        .senderProfileImg(message.getSenderProfileImg())
                         .senderUsername(message.getSenderUsername())
                         .senderNickname(message.getSenderNickname())
                         .regDate(TimeUtil.convertTimeTypeToLocalDateTime(message.getSendTime()))

--- a/src/main/resources/application-han.yml
+++ b/src/main/resources/application-han.yml
@@ -1,0 +1,58 @@
+# environment variables must be in .env file of root directory
+spring:
+  config:
+    import: optional:file:.env[.properties]
+  thymeleaf:
+    prefix: classpath:/template/
+    suffix: .html
+    enabled: true
+  datasource:
+    url: ${LOCAL_MYSQL_URL}
+    username: ${LOCAL_MYSQL_USERNAME}
+    password: ${LOCAL_MYSQL_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: update # according to our dev environment
+
+  data:
+    mongodb:
+      uri: mongodb://localhost:27017/chatty_db
+
+  rabbitmq:
+    host: ${LOCAL_RABBITMQ_HOST}
+    port: ${LOCAL_RABBITMQ_PORT}
+    username: ${LOCAL_RABBITMQ_USERNAME}
+    password: ${LOCAL_RABBITMQ_PASSWORD}
+
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${LOCAL_GOOGLE_CLIENT_ID}
+            client-secret: ${LOCAL_GOOGLE_CLIENT_SECRET}
+            redirect-uri: ${LOCAL_GOOGLE_REDIRECT_URI}
+          github:
+            client-id: ${LOCAL_GITHUB_CLIENT_ID}
+            client-secret: ${LOCAL_GITHUB_CLIENT_SECRET}
+            redirect-uri: ${LOCAL_GITHUB_REDIRECT_URI}
+
+
+variables:
+  cloud:
+    s3:
+      bucketName: ${LOCAL_S3_BUCKET_NAME}
+      accessKey: ${LOCAL_S3_ACCESS_KEY}
+      secretKey: ${LOCAL_S3_SECRET_KEY}
+  jwt:
+    KEY: ${LOCAL_JWT_SECRET_KEY}
+  invitation:
+    KEY: ${LOCAL_INVITATION_SECRET_KEY}
+  password:
+    KEY: ${LOCAL_PASSWORD_SECRET_KEY}
+
+mongodb:
+  client: mongodb://localhost:27017
+  name: chat_db

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 # common setting
 spring:
   profiles:
-    active: local
+    active: han
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 # common setting
 spring:
   profiles:
-    active: han
+    active: deploy
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:

--- a/src/main/resources/template/chat/room.html
+++ b/src/main/resources/template/chat/room.html
@@ -113,7 +113,7 @@
       messageContent.value = ''; // 입력 필드 초기화
 
       // MessageDto 객체로 변환하여 메시지 전송
-      const messageDto = {
+      const messageResponseDto = {
           id: null,
           channelId: channelId,
           content: message
@@ -123,7 +123,7 @@
       stomp.send(`/pub/chat.message`, {
           'channelId': channelId,
           'Authorization': `Bearer ${accessToken}`
-      }, JSON.stringify(messageDto));
+      }, JSON.stringify(messageResponseDto));
   });
 
   // Disconnect 버튼 처리

--- a/src/main/resources/template/chat/room.html
+++ b/src/main/resources/template/chat/room.html
@@ -54,7 +54,7 @@
   const btnSend = document.querySelector('.btn-send');
   const disconnectBtn = document.getElementById('disconnectBtn');
   const channelId = [[${channelId}]];
-  const workspaceId = [[${workspaceId}]];
+  const workspaceJoinId = [[${workspaceJoinId}]];
   const accessToken = [[${accessToken}]]; // 서버로부터 전달된 accessToken
   const nickname = [[${nickname}]]; // 서버로부터 전달된 사용자 이름
   const profileImg = [[${profileImg}]]; // 필요한 경우, 프로필 이미지 URL을 추가
@@ -78,6 +78,7 @@
 
   stomp.connect({
       'channelId': channelId,
+      'workspaceJoinId': workspaceJoinId,
       'Authorization': `Bearer ${accessToken}`
   }, function (frame) {
       console.log('STOMP Connected');
@@ -96,13 +97,6 @@
           chats.insertAdjacentHTML('beforeend', html);
       }, { 'auto-delete': true, 'durable': false, 'exclusive': false });
 
-      // 연결이 성공하면 입장 메시지를 전송
-      stomp.send(`/pub/chat.enter.${channelId}`, {}, JSON.stringify({
-          id: null, // 메시지 ID는 서버에서 생성
-          channelId: channelId,
-          content: `${nickname}님이 입장하셨습니다.`
-      }));
-
   }, onError);
 
   // 메시지 전송 폼 처리
@@ -115,7 +109,7 @@
       // MessageDto 객체로 변환하여 메시지 전송
       const messageDto = {
           channelId: channelId,
-          workspaceId: workspaceId,
+          workspaceJoinId: workspaceJoinId,
           senderProfileImg: profileImg,
           senderNickname: nickname,
           content: message
@@ -123,12 +117,12 @@
 
       // 메시지 전송
       stomp.send(`/pub/chat.message`, {
-          'channelId': channelId,
-          'workspaceId' : workspaceId,
-          'profileImg' : profileImg,
+          'channelId': channelId.toString(),         // 문자열로 변환하여 전송
+          'workspaceJoinId': workspaceJoinId?.toString(), // workspaceJoinId가 null이면 undefined 방지
           'nickname': nickname,
+          'profileImg': profileImg,
           'Authorization': `Bearer ${accessToken}`
-      }, JSON.stringify(messageResponseDto));
+      }, JSON.stringify(messageDto));
   });
 
   // Disconnect 버튼 처리

--- a/src/main/resources/template/chat/room.html
+++ b/src/main/resources/template/chat/room.html
@@ -54,10 +54,10 @@
   const btnSend = document.querySelector('.btn-send');
   const disconnectBtn = document.getElementById('disconnectBtn');
   const channelId = [[${channelId}]];
-  const nickname = [[${nickname}]];
+  const workspaceId = [[${workspaceId}]];
   const accessToken = [[${accessToken}]]; // 서버로부터 전달된 accessToken
-  const senderUsername = [[${username}]]; // 서버로부터 전달된 사용자 이름
-  const senderProfileImg = ""; // 필요한 경우, 프로필 이미지 URL을 추가
+  const nickname = [[${nickname}]]; // 서버로부터 전달된 사용자 이름
+  const profileImg = [[${profileImg}]]; // 필요한 경우, 프로필 이미지 URL을 추가
 
   const sockJS = new SockJS("/stomp/chat");
   const stomp = Stomp.over(sockJS);
@@ -113,15 +113,20 @@
       messageContent.value = ''; // 입력 필드 초기화
 
       // MessageDto 객체로 변환하여 메시지 전송
-      const messageResponseDto = {
-          id: null,
+      const messageDto = {
           channelId: channelId,
+          workspaceId: workspaceId,
+          senderProfileImg: profileImg,
+          senderNickname: nickname,
           content: message
       };
 
       // 메시지 전송
       stomp.send(`/pub/chat.message`, {
           'channelId': channelId,
+          'workspaceId' : workspaceId,
+          'profileImg' : profileImg,
+          'nickname': nickname,
           'Authorization': `Bearer ${accessToken}`
       }, JSON.stringify(messageResponseDto));
   });


### PR DESCRIPTION
# WORK
1. 채팅의 connect -> subscribe -> send과정에서 사용할 수 있는 항목을 변경(username 제거, workspaceJoinId추가)
2. workspaceJoinId를 통해 memberInfo를 가져올 수 있도록 함(subscribe 단계에서만)
3. message dto divide(request, response)
4. messageListDto추가(마지막 페이지 체크, 마지막 조회 아이디 체크 필드 추가)
5. workspaceId를 통해 채널 간단 조회 시, 안읽은 메세지 개수 필드 추가