### PR TITLE
[Refactor/#30] edit getMessageInChannel method in channelController.c…

### DIFF
--- a/src/main/java/com/messenger/chatty/domain/channel/controller/ChannelController.java
+++ b/src/main/java/com/messenger/chatty/domain/channel/controller/ChannelController.java
@@ -35,6 +35,9 @@ public class ChannelController {
         Pageable pageable = PageRequest.of(currentPage, 10);
         MessageListDto messages = messageService.getMessages(channelId, pageable);
         Long workspaceJoinId = channelService.getWorkspaceJoinId(channelId, username);
+        if (!channelService.hasAccessTime(channelId, workspaceJoinId)) {
+            channelService.createAccessTime(channelId, workspaceJoinId);
+        }
         String lastReadMessageId = messageService.getLastReadMessageId(channelId, workspaceJoinId);
         messages.setHavePoint(messages.getMessageResponseDtoList().stream()
                 .anyMatch(dto -> dto.getId().equals(lastReadMessageId)));


### PR DESCRIPTION
# Issue
- https://github.com/project-web-chatty/chatty-server/issues/30

# WORK
* 상황 : 채널 생성후 접속 시 4073 에러 발생, 하지만 재접속 시 문제 없음
* 문제 : 새로 추가된 컨트롤러의 메서드 messageService.getLastMessageId()에 접속 시간을 위한 ChannelAccess 엔티티에 관한 메서드가 포함되어있기 때문에 발생. chatPreHandler에서 채널 subsrcibe 및 disconnect과정까지 생성 x
* 해결 :  따라서 채널 조회 시에도 엔티티 존재 확인 및 생성 과정 추가